### PR TITLE
Added unit tests for the upper function

### DIFF
--- a/tests/test_upper.py
+++ b/tests/test_upper.py
@@ -1,10 +1,7 @@
 import pytest
 
 import arrayfire_wrapper.dtypes as dtypes
-from arrayfire_wrapper.lib.create_and_modify_array.create_array.constant import constant
-from arrayfire_wrapper.lib.create_and_modify_array.create_array.diag import diag_extract
-from arrayfire_wrapper.lib.create_and_modify_array.create_array.upper import upper
-from arrayfire_wrapper.lib.create_and_modify_array.manage_array import get_scalar
+import arrayfire_wrapper.lib as wrapper
 
 
 @pytest.mark.parametrize(
@@ -18,11 +15,11 @@ from arrayfire_wrapper.lib.create_and_modify_array.manage_array import get_scala
 def test_diag_is_unit(shape: tuple) -> None:
     """Test if when is_unit_diag in lower returns an array with a unit diagonal"""
     dtype = dtypes.s64
-    constant_array = constant(3, shape, dtype)
+    constant_array = wrapper.constant(3, shape, dtype)
 
-    lower_array = upper(constant_array, True)
-    diagonal = diag_extract(lower_array, 0)
-    diagonal_value = get_scalar(diagonal, dtype)
+    lower_array = wrapper.upper(constant_array, True)
+    diagonal = wrapper.diag_extract(lower_array, 0)
+    diagonal_value = wrapper.get_scalar(diagonal, dtype)
 
     assert diagonal_value == 1
 
@@ -38,11 +35,11 @@ def test_diag_is_unit(shape: tuple) -> None:
 def test_is_original(shape: tuple) -> None:
     """Test if is_original keeps the diagonal the same as the original array"""
     dtype = dtypes.s64
-    constant_array = constant(3, shape, dtype)
-    original_value = get_scalar(constant_array, dtype)
+    constant_array = wrapper.constant(3, shape, dtype)
+    original_value = wrapper.get_scalar(constant_array, dtype)
 
-    lower_array = upper(constant_array, False)
-    diagonal = diag_extract(lower_array, 0)
-    diagonal_value = get_scalar(diagonal, dtype)
+    lower_array = wrapper.upper(constant_array, False)
+    diagonal = wrapper.diag_extract(lower_array, 0)
+    diagonal_value = wrapper.get_scalar(diagonal, dtype)
 
     assert original_value == diagonal_value

--- a/tests/test_upper.py
+++ b/tests/test_upper.py
@@ -1,0 +1,48 @@
+import pytest
+
+import arrayfire_wrapper.dtypes as dtypes
+from arrayfire_wrapper.lib.create_and_modify_array.create_array.constant import constant
+from arrayfire_wrapper.lib.create_and_modify_array.create_array.diag import diag_extract
+from arrayfire_wrapper.lib.create_and_modify_array.create_array.upper import upper
+from arrayfire_wrapper.lib.create_and_modify_array.manage_array import get_scalar
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 3),
+        (3, 3, 3),
+        (3, 3, 3, 3),
+    ],
+)
+def test_diag_is_unit(shape: tuple) -> None:
+    """Test if when is_unit_diag in lower returns an array with a unit diagonal"""
+    dtype = dtypes.s64
+    constant_array = constant(3, shape, dtype)
+
+    lower_array = upper(constant_array, True)
+    diagonal = diag_extract(lower_array, 0)
+    diagonal_value = get_scalar(diagonal, dtype)
+
+    assert diagonal_value == 1
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 3),
+        (3, 3, 3),
+        (3, 3, 3, 3),
+    ],
+)
+def test_is_original(shape: tuple) -> None:
+    """Test if is_original keeps the diagonal the same as the original array"""
+    dtype = dtypes.s64
+    constant_array = constant(3, shape, dtype)
+    original_value = get_scalar(constant_array, dtype)
+
+    lower_array = upper(constant_array, False)
+    diagonal = diag_extract(lower_array, 0)
+    diagonal_value = get_scalar(diagonal, dtype)
+
+    assert original_value == diagonal_value


### PR DESCRIPTION
This PR introduces a suite of unit tests for upper.py located within the within the create_array directory. The primary functions in this file facilitate the creation of an an array with only the upper triangular portion, and an option of whether to convert original array's diagonal to a unit diagonal or not.

Diagonal: Ensures that the diagonal of the new array meets the parameter setting of whether it should be a unit diagonal or not.