### PR TITLE
Added unit tests for the pad function and fixed pad function return v…

### DIFF
--- a/arrayfire_wrapper/lib/create_and_modify_array/create_array/pad.py
+++ b/arrayfire_wrapper/lib/create_and_modify_array/create_array/pad.py
@@ -22,4 +22,4 @@ def pad(arr: AFArray, begin_shape: tuple[int, ...], end_shape: tuple[int, ...], 
         end_c_shape.c_array,
         border_type.value,
     )
-    return NotImplemented
+    return out

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -1,0 +1,74 @@
+import random
+
+import numpy as np
+import pytest
+
+import arrayfire_wrapper.dtypes as dtypes
+from arrayfire_wrapper.lib._constants import Pad
+from arrayfire_wrapper.lib.create_and_modify_array.create_array.constant import constant
+from arrayfire_wrapper.lib.create_and_modify_array.create_array.pad import pad
+from arrayfire_wrapper.lib.create_and_modify_array.manage_array import get_dims
+
+
+@pytest.mark.parametrize(
+    "original_shape",
+    [
+        (random.randint(1, 100),),
+        (random.randint(1, 100), random.randint(1, 100)),
+        (random.randint(1, 100), random.randint(1, 100), random.randint(1, 100)),
+        (random.randint(1, 100), random.randint(1, 100), random.randint(1, 100), random.randint(1, 100)),
+    ],
+)
+def test_zero_padding(original_shape: tuple) -> None:
+    """Test if pad creates an array with no padding if no padding is given"""
+    original_array = constant(2, original_shape, dtypes.s64)
+    padding = Pad(0)
+
+    zero_shape = tuple(0 for _ in range(len(original_shape)))
+    result = pad(original_array, zero_shape, zero_shape, padding)
+
+    assert get_dims(result)[0:len(original_shape)] == original_shape
+
+
+@pytest.mark.parametrize(
+    "original_shape",
+    [
+        (random.randint(1, 100),),
+        (random.randint(1, 100), random.randint(1, 100)),
+        (random.randint(1, 100), random.randint(1, 100), random.randint(1, 100)),
+        (random.randint(1, 100), random.randint(1, 100), random.randint(1, 100), random.randint(1, 100)),
+    ],
+)
+def test_negative_padding(original_shape: tuple) -> None:
+    """Test if pad can properly handle if negative padding is given"""
+    with pytest.raises(RuntimeError):
+        original_array = constant(2, original_shape, dtypes.s64)
+        padding = Pad(0)
+
+        neg_shape = tuple(-1 for _ in range(len(original_shape)))
+        result = pad(original_array, neg_shape, neg_shape, padding)
+
+        assert get_dims(result)[0:len(original_shape)] == original_shape
+
+
+@pytest.mark.parametrize(
+    "original_shape",
+    [
+        (random.randint(1, 100),),
+        (random.randint(1, 100), random.randint(1, 100)),
+        (random.randint(1, 100), random.randint(1, 100), random.randint(1, 100)),
+        (random.randint(1, 100), random.randint(1, 100), random.randint(1, 100), random.randint(1, 100)),
+    ],
+)
+def test_padding_shape(original_shape: tuple) -> None:
+    """Test if pad outputs the correct shape when a padding is adding to the original array"""
+    original_array = constant(2, original_shape, dtypes.s64)
+    padding = Pad(0)
+
+    beg_shape = tuple(random.randint(1, 10) for _ in range(len(original_shape)))
+    end_shape = tuple(random.randint(1, 10) for _ in range(len(original_shape)))
+
+    result = pad(original_array, beg_shape, end_shape, padding)
+    new_shape = np.array(beg_shape) + np.array(end_shape) + np.array(original_shape)
+
+    assert get_dims(result)[0:len(original_shape)] == tuple(new_shape)

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -4,10 +4,7 @@ import numpy as np
 import pytest
 
 import arrayfire_wrapper.dtypes as dtypes
-from arrayfire_wrapper.lib._constants import Pad
-from arrayfire_wrapper.lib.create_and_modify_array.create_array.constant import constant
-from arrayfire_wrapper.lib.create_and_modify_array.create_array.pad import pad
-from arrayfire_wrapper.lib.create_and_modify_array.manage_array import get_dims
+import arrayfire_wrapper.lib as wrapper
 
 
 @pytest.mark.parametrize(
@@ -21,13 +18,13 @@ from arrayfire_wrapper.lib.create_and_modify_array.manage_array import get_dims
 )
 def test_zero_padding(original_shape: tuple) -> None:
     """Test if pad creates an array with no padding if no padding is given"""
-    original_array = constant(2, original_shape, dtypes.s64)
-    padding = Pad(0)
+    original_array = wrapper.constant(2, original_shape, dtypes.s64)
+    padding = wrapper.Pad(0)
 
     zero_shape = tuple(0 for _ in range(len(original_shape)))
-    result = pad(original_array, zero_shape, zero_shape, padding)
+    result = wrapper.pad(original_array, zero_shape, zero_shape, padding)
 
-    assert get_dims(result)[0:len(original_shape)] == original_shape
+    assert wrapper.get_dims(result)[0 : len(original_shape)] == original_shape  # noqa: E203
 
 
 @pytest.mark.parametrize(
@@ -42,13 +39,13 @@ def test_zero_padding(original_shape: tuple) -> None:
 def test_negative_padding(original_shape: tuple) -> None:
     """Test if pad can properly handle if negative padding is given"""
     with pytest.raises(RuntimeError):
-        original_array = constant(2, original_shape, dtypes.s64)
-        padding = Pad(0)
+        original_array = wrapper.constant(2, original_shape, dtypes.s64)
+        padding = wrapper.Pad(0)
 
         neg_shape = tuple(-1 for _ in range(len(original_shape)))
-        result = pad(original_array, neg_shape, neg_shape, padding)
+        result = wrapper.pad(original_array, neg_shape, neg_shape, padding)
 
-        assert get_dims(result)[0:len(original_shape)] == original_shape
+        assert wrapper.get_dims(result)[0 : len(original_shape)] == original_shape  # noqa: E203
 
 
 @pytest.mark.parametrize(
@@ -62,13 +59,13 @@ def test_negative_padding(original_shape: tuple) -> None:
 )
 def test_padding_shape(original_shape: tuple) -> None:
     """Test if pad outputs the correct shape when a padding is adding to the original array"""
-    original_array = constant(2, original_shape, dtypes.s64)
-    padding = Pad(0)
+    original_array = wrapper.constant(2, original_shape, dtypes.s64)
+    padding = wrapper.Pad(0)
 
     beg_shape = tuple(random.randint(1, 10) for _ in range(len(original_shape)))
     end_shape = tuple(random.randint(1, 10) for _ in range(len(original_shape)))
 
-    result = pad(original_array, beg_shape, end_shape, padding)
+    result = wrapper.pad(original_array, beg_shape, end_shape, padding)
     new_shape = np.array(beg_shape) + np.array(end_shape) + np.array(original_shape)
 
-    assert get_dims(result)[0:len(original_shape)] == tuple(new_shape)
+    assert wrapper.get_dims(result)[0 : len(original_shape)] == tuple(new_shape)  # noqa: E203


### PR DESCRIPTION
This PR introduces a suite of unit tests for pad.py located within the create_array directory. The primary function in this file is to add padding to a given array. 

No Padding: Ensures that when given 0 padding, the array remains its original shape
Negative Padding: Ensures that when given negative padding, the pad function properly handles this case
Padding Shape: Ensures that when padding is added, the correct padding shape is seen in the padded array

Pad Return Value Fix: Pad originally returned "Not Implemented" 